### PR TITLE
feat: add onboard knowledge graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ quick-data-mcp/ai_docs
 CONNECTION_ISSUES_ANALYSIS.md
 SMITHERY_LOGS.md
 debug-wrapper.js
+knowledge-graph.json

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ This MCP server provides three essential tools and seven agentic prompts:
 - **websets_manager**: A comprehensive tool for managing content collections, searches, and data enhancements
 - **web_search_exa**: Real-time web search capabilities powered by Exa AI
 - **websets_guide**: Helpful guidance and examples for using websets effectively
+- **knowledge_graph**: Maintain connections between webset results in an onboard graph
 
 ### Prompts (NEW!)
 Interactive workflows to guide you through websets operations:

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { toolRegistry } from "./tools/config.js";
 // Import tools to register them
 import "./tools/webSearch.js";
 import "./tools/websetsManager.js";
+import "./tools/knowledgeGraph.js";
 
 // Import feature flags
 import { featureFlags } from "./config/features.js";
@@ -56,10 +57,11 @@ const colors = {
  * This MCP server provides Exa AI's websets management capabilities and basic web search
  * functionality to AI assistants through the Model Context Protocol.
  * 
- * The server provides three essential tools:
+ * The server provides four essential tools:
  * - websets_manager: Comprehensive websets management
  * - web_search_exa: Real-time web searching capabilities
  * - websets_guide: Helpful guidance for using websets
+ * - knowledge_graph: Onboard graph to track connections between webset results
  */
 export class ExaWebsetsServer {
   private app: express.Application;
@@ -111,11 +113,12 @@ export class ExaWebsetsServer {
    */
   private registerTools(): void {
     // Create our simplified tool registry with three tools
-    const simplifiedRegistry = {
-      web_search_exa: toolRegistry["web_search_exa"],
-      websets_manager: toolRegistry["websets_manager"],
-      websets_guide: websetsGuideTool
-    };
+      const simplifiedRegistry = {
+        web_search_exa: toolRegistry["web_search_exa"],
+        websets_manager: toolRegistry["websets_manager"],
+        websets_guide: websetsGuideTool,
+        knowledge_graph: toolRegistry["knowledge_graph"],
+      };
     
     // Register our tools
     Object.values(simplifiedRegistry).forEach(tool => {

--- a/src/prompts/listMcpAssets.ts
+++ b/src/prompts/listMcpAssets.ts
@@ -22,10 +22,11 @@ Interactive conversation starters and analysis guides:
 ## 🔧 Tools
 Webset management and analysis functions:
 
-### Core Webset Operations
-• **websets_search** (query, limit) - Search the web and create new websets asynchronously
-• **websets_search_guide** () - Learn to use websets search effectively
-• **websets_manager** (action, params) - Advanced webset management operations
+  ### Core Webset Operations
+  • **websets_search** (query, limit) - Search the web and create new websets asynchronously
+  • **websets_search_guide** () - Learn to use websets search effectively
+  • **websets_manager** (action, params) - Advanced webset management operations
+  • **knowledge_graph** (operation, params) - Maintain connections between webset results
 
 ### Webset Management
 • **list_websets** () - List all your websets with status and metadata

--- a/src/services/KnowledgeGraphService.ts
+++ b/src/services/KnowledgeGraphService.ts
@@ -1,0 +1,153 @@
+import { promises as fs } from 'fs';
+import path from 'path';
+
+export interface GraphEntity {
+  name: string;
+  entityType: string;
+  observations: string[];
+}
+
+export interface GraphRelation {
+  from: string;
+  to: string;
+  relationType: string;
+}
+
+export interface KnowledgeGraph {
+  entities: GraphEntity[];
+  relations: GraphRelation[];
+}
+
+/**
+ * Simple persistent knowledge graph store.
+ *
+ * Stores entities and relations in a newline-separated JSON file so the
+ * graph can survive server restarts without requiring an external database.
+ */
+export class KnowledgeGraphService {
+  private filePath: string;
+
+  constructor(filePath?: string) {
+    const defaultPath = path.join(process.cwd(), 'knowledge-graph.json');
+    const resolved = filePath || process.env.KG_FILE_PATH || defaultPath;
+    this.filePath = path.isAbsolute(resolved)
+      ? resolved
+      : path.join(process.cwd(), resolved);
+  }
+
+  private async loadGraph(): Promise<KnowledgeGraph> {
+    try {
+      const data = await fs.readFile(this.filePath, 'utf-8');
+      const lines = data.split('\n').filter(line => line.trim() !== '');
+      return lines.reduce<KnowledgeGraph>((graph, line) => {
+        const item = JSON.parse(line);
+        if (item.type === 'entity') graph.entities.push(item as GraphEntity);
+        if (item.type === 'relation') graph.relations.push(item as GraphRelation);
+        return graph;
+      }, { entities: [], relations: [] });
+    } catch (err: any) {
+      if (err && err.code === 'ENOENT') {
+        return { entities: [], relations: [] };
+      }
+      throw err;
+    }
+  }
+
+  private async saveGraph(graph: KnowledgeGraph): Promise<void> {
+    const lines = [
+      ...graph.entities.map(e => JSON.stringify({ type: 'entity', ...e })),
+      ...graph.relations.map(r => JSON.stringify({ type: 'relation', ...r })),
+    ];
+    await fs.writeFile(this.filePath, lines.join('\n'));
+  }
+
+  async createEntities(entities: GraphEntity[]): Promise<GraphEntity[]> {
+    const graph = await this.loadGraph();
+    const newEntities = entities.filter(e => !graph.entities.some(ex => ex.name === e.name));
+    graph.entities.push(...newEntities);
+    await this.saveGraph(graph);
+    return newEntities;
+  }
+
+  async createRelations(relations: GraphRelation[]): Promise<GraphRelation[]> {
+    const graph = await this.loadGraph();
+    const newRelations = relations.filter(r => !graph.relations.some(ex =>
+      ex.from === r.from && ex.to === r.to && ex.relationType === r.relationType
+    ));
+    graph.relations.push(...newRelations);
+    await this.saveGraph(graph);
+    return newRelations;
+  }
+
+  async addObservations(observations: { entityName: string; contents: string[] }[])
+    : Promise<{ entityName: string; addedObservations: string[] }[]> {
+    const graph = await this.loadGraph();
+    const results = observations.map(o => {
+      const entity = graph.entities.find(e => e.name === o.entityName);
+      if (!entity) {
+        throw new Error(`Entity with name ${o.entityName} not found`);
+      }
+      const newObs = o.contents.filter(c => !entity.observations.includes(c));
+      entity.observations.push(...newObs);
+      return { entityName: o.entityName, addedObservations: newObs };
+    });
+    await this.saveGraph(graph);
+    return results;
+  }
+
+  async deleteEntities(names: string[]): Promise<void> {
+    const graph = await this.loadGraph();
+    graph.entities = graph.entities.filter(e => !names.includes(e.name));
+    graph.relations = graph.relations.filter(r => !names.includes(r.from) && !names.includes(r.to));
+    await this.saveGraph(graph);
+  }
+
+  async deleteObservations(deletions: { entityName: string; observations: string[] }[]): Promise<void> {
+    const graph = await this.loadGraph();
+    deletions.forEach(d => {
+      const entity = graph.entities.find(e => e.name === d.entityName);
+      if (entity) {
+        entity.observations = entity.observations.filter(o => !d.observations.includes(o));
+      }
+    });
+    await this.saveGraph(graph);
+  }
+
+  async deleteRelations(relations: GraphRelation[]): Promise<void> {
+    const graph = await this.loadGraph();
+    graph.relations = graph.relations.filter(r => !relations.some(del =>
+      r.from === del.from && r.to === del.to && r.relationType === del.relationType
+    ));
+    await this.saveGraph(graph);
+  }
+
+  async readGraph(): Promise<KnowledgeGraph> {
+    return this.loadGraph();
+  }
+
+  async searchNodes(query: string): Promise<KnowledgeGraph> {
+    const graph = await this.loadGraph();
+    const filteredEntities = graph.entities.filter(e =>
+      e.name.toLowerCase().includes(query.toLowerCase()) ||
+      e.entityType.toLowerCase().includes(query.toLowerCase()) ||
+      e.observations.some(o => o.toLowerCase().includes(query.toLowerCase()))
+    );
+    const names = new Set(filteredEntities.map(e => e.name));
+    const filteredRelations = graph.relations.filter(r =>
+      names.has(r.from) && names.has(r.to)
+    );
+    return { entities: filteredEntities, relations: filteredRelations };
+  }
+
+  async openNodes(names: string[]): Promise<KnowledgeGraph> {
+    const graph = await this.loadGraph();
+    const filteredEntities = graph.entities.filter(e => names.includes(e.name));
+    const nameSet = new Set(filteredEntities.map(e => e.name));
+    const filteredRelations = graph.relations.filter(r =>
+      nameSet.has(r.from) && nameSet.has(r.to)
+    );
+    return { entities: filteredEntities, relations: filteredRelations };
+  }
+}
+
+export default KnowledgeGraphService;

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -6,6 +6,7 @@ import "./webSearch.js";
 import "./websetsManager.js";
 import "./websetsGuide.js";
 import "./mem0Store.js";
+import "./knowledgeGraph.js";
 
 // When adding a new tool, import it here
 // import "./newTool.js";

--- a/src/tools/knowledgeGraph.ts
+++ b/src/tools/knowledgeGraph.ts
@@ -1,0 +1,87 @@
+import { z } from 'zod';
+import { toolRegistry, ToolCategory, ServiceType } from './config.js';
+import { createRequestLogger } from '../utils/logger.js';
+import KnowledgeGraphService from '../services/KnowledgeGraphService.js';
+
+const knowledgeGraph = new KnowledgeGraphService();
+
+const KnowledgeGraphSchema = z.object({
+  operation: z.enum([
+    'create_entities',
+    'create_relations',
+    'add_observations',
+    'delete_entities',
+    'delete_observations',
+    'delete_relations',
+    'read_graph',
+    'search_nodes',
+    'open_nodes'
+  ]),
+  entities: z.array(z.object({
+    name: z.string(),
+    entityType: z.string(),
+    observations: z.array(z.string()).default([])
+  })).optional(),
+  relations: z.array(z.object({
+    from: z.string(),
+    to: z.string(),
+    relationType: z.string()
+  })).optional(),
+  observations: z.array(z.object({
+    entityName: z.string(),
+    contents: z.array(z.string())
+  })).optional(),
+  deletions: z.array(z.object({
+    entityName: z.string(),
+    observations: z.array(z.string())
+  })).optional(),
+  names: z.array(z.string()).optional(),
+  query: z.string().optional()
+});
+
+toolRegistry['knowledge_graph'] = {
+  name: 'knowledge_graph',
+  description: 'Maintain an onboard knowledge graph of webset results.',
+  schema: KnowledgeGraphSchema.shape,
+  category: ToolCategory.WEBSETS,
+  service: ServiceType.WEBSETS,
+  handler: async (args) => {
+    const { operation, entities, relations, observations, deletions, names, query } = args;
+    const requestId = `knowledge_graph-${Date.now()}-${Math.random().toString(36).slice(2,7)}`;
+    const logger = createRequestLogger(requestId, 'knowledge_graph');
+    logger.start(operation);
+    try {
+      switch (operation) {
+        case 'create_entities':
+          return { content: [{ type: 'text', text: JSON.stringify(await knowledgeGraph.createEntities(entities || []), null, 2) }] };
+        case 'create_relations':
+          return { content: [{ type: 'text', text: JSON.stringify(await knowledgeGraph.createRelations(relations || []), null, 2) }] };
+        case 'add_observations':
+          return { content: [{ type: 'text', text: JSON.stringify(await knowledgeGraph.addObservations(observations || []), null, 2) }] };
+        case 'delete_entities':
+          await knowledgeGraph.deleteEntities(names || []);
+          return { content: [{ type: 'text', text: 'Entities deleted successfully' }] };
+        case 'delete_observations':
+          await knowledgeGraph.deleteObservations(deletions || []);
+          return { content: [{ type: 'text', text: 'Observations deleted successfully' }] };
+        case 'delete_relations':
+          await knowledgeGraph.deleteRelations(relations || []);
+          return { content: [{ type: 'text', text: 'Relations deleted successfully' }] };
+        case 'read_graph':
+          return { content: [{ type: 'text', text: JSON.stringify(await knowledgeGraph.readGraph(), null, 2) }] };
+        case 'search_nodes':
+          return { content: [{ type: 'text', text: JSON.stringify(await knowledgeGraph.searchNodes(query || ''), null, 2) }] };
+        case 'open_nodes':
+          return { content: [{ type: 'text', text: JSON.stringify(await knowledgeGraph.openNodes(names || []), null, 2) }] };
+        default:
+          throw new Error(`Unknown operation: ${operation}`);
+      }
+    } catch (error: any) {
+      logger.error(error);
+      return { content: [{ type: 'text', text: `Knowledge graph error: ${error.message}` }], isError: true };
+    }
+  },
+  enabled: true
+};
+
+export default toolRegistry['knowledge_graph'];


### PR DESCRIPTION
## Summary
- implement persistent knowledge graph service for webset results
- expose knowledge graph management via new `knowledge_graph` tool
- register and document knowledge graph functionality

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68949cfc13bc8325accb81306bc48c9d